### PR TITLE
Fix of regression tests

### DIFF
--- a/ubl/examples/ubl-tc434-example2.xml
+++ b/ubl/examples/ubl-tc434-example2.xml
@@ -168,7 +168,7 @@
             Penalty percentage 10% from due date</cbc:Note>        
     </cac:PaymentTerms>
     <cac:AllowanceCharge>
-        <cbc:ChargeIndicator>0</cbc:ChargeIndicator>
+        <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
         <cbc:AllowanceChargeReasonCode>75</cbc:AllowanceChargeReasonCode>
         <cbc:AllowanceChargeReason>Promotion discount</cbc:AllowanceChargeReason>
         <cbc:Amount currencyID="NOK">100.00</cbc:Amount>


### PR DESCRIPTION
**<cbc:ChargeIndicator>** is not allowed to have the value '0', but only 'false' and 'true'

_https://docs.oasis-open.org/ubl/os-UBL-2.0/xsd/common/UBL-CommonBasicComponents-2.0.xsd_

<xsd:element name="**ChargeIndicator**" type="ChargeIndicatorType"/>
    <xsd:complexType name="ChargeIndicatorType">
        <xsd:simpleContent>
           <xsd:extension base="**udt:IndicatorType**"/>
         </xsd:simpleContent>
     </xsd:complexType>

for **xmlns:udt**="urn:un:unece:uncefact:data:specification:UnqualifiedDataTypesSchemaModule:2"
see
_https://docs.oasis-open.org/ubl/os-UBL-2.0/xsd/common/UnqualifiedDataTypeSchemaModule-2.0.xsd_

<xsd:simpleType name="**IndicatorType**">
    <xsd:annotation>
        <xsd:documentation xml:lang="en">
            <ccts:UniqueID>UDT0000012</ccts:UniqueID>
            <ccts:CategoryCode>UDT</ccts:CategoryCode>
            <ccts:DictionaryEntryName>Indicator. Type</ccts:DictionaryEntryName>
            <ccts:VersionID>1.0</ccts:VersionID>
            <ccts:Definition>A list of two mutually exclusive Boolean values that express the only possible states of a property.</ccts:Definition>
            <ccts:RepresentationTermName>Indicator</ccts:RepresentationTermName>
            <ccts:PrimitiveType>string</ccts:PrimitiveType>
            <xsd:BuiltinType>boolean</xsd:BuiltinType>
        </xsd:documentation>
    </xsd:annotation>
    <xsd:restriction base="xsd:boolean">
        <xsd:pattern value="**false**"/>
        <xsd:pattern value="**true**"/>
    </xsd:restriction>
</xsd:simpleType>
