### PR TITLE
Fixes #139 - Using 'VA' instead 'VAT' as schemeID value according to BT-31 and BT-63

### DIFF
--- a/cii/instance/CII_business_example_01.xml
+++ b/cii/instance/CII_business_example_01.xml
@@ -131,7 +131,7 @@
           <ram:CountryID>DE</ram:CountryID>
         </ram:PostalTradeAddress>
         <ram:SpecifiedTaxRegistration>
-          <ram:ID schemeID="VAT">DE37/302/30168</ram:ID>
+          <ram:ID schemeID="VA">DE37/302/30168</ram:ID>
         </ram:SpecifiedTaxRegistration>
       </ram:SellerTradeParty>
       <ram:BuyerTradeParty>

--- a/cii/instance/CII_business_example_02.xml
+++ b/cii/instance/CII_business_example_02.xml
@@ -122,7 +122,7 @@
                     <ram:CountryID>DE</ram:CountryID>
                 </ram:PostalTradeAddress>
                 <ram:SpecifiedTaxRegistration>
-                    <ram:ID schemeID="VAT">DE1111111</ram:ID>
+                    <ram:ID schemeID="VA">DE1111111</ram:ID>
                 </ram:SpecifiedTaxRegistration>
             </ram:SellerTradeParty>
             <ram:BuyerTradeParty>

--- a/cii/instance/CII_example1.xml
+++ b/cii/instance/CII_example1.xml
@@ -578,7 +578,7 @@
                     <ram:CountryID>NL</ram:CountryID>
                 </ram:PostalTradeAddress>
                 <ram:SpecifiedTaxRegistration>
-                    <ram:ID schemeID="VAT">NL8200.98.395.B.01</ram:ID>
+                    <ram:ID schemeID="VA">NL8200.98.395.B.01</ram:ID>
                 </ram:SpecifiedTaxRegistration>
             </ram:SellerTradeParty>
             <ram:BuyerTradeParty>

--- a/cii/instance/CII_example2.xml
+++ b/cii/instance/CII_example2.xml
@@ -302,7 +302,7 @@
                     <ram:CountrySubDivisionName>RegionA</ram:CountrySubDivisionName>
                 </ram:PostalTradeAddress>
                 <ram:SpecifiedTaxRegistration>
-                    <ram:ID schemeID="VAT">NO123456789MVA</ram:ID>
+                    <ram:ID schemeID="VA">NO123456789MVA</ram:ID>
                 </ram:SpecifiedTaxRegistration>
             </ram:SellerTradeParty>
             <ram:BuyerTradeParty>
@@ -329,7 +329,7 @@
                     <ram:CountrySubDivisionName>RegionB</ram:CountrySubDivisionName>
                 </ram:PostalTradeAddress>
                 <ram:SpecifiedTaxRegistration>
-                    <ram:ID schemeID="VAT">NO987654321MVA</ram:ID>
+                    <ram:ID schemeID="VA">NO987654321MVA</ram:ID>
                 </ram:SpecifiedTaxRegistration>
             </ram:BuyerTradeParty>
             <ram:SellerTaxRepresentativeTradeParty>
@@ -343,7 +343,7 @@
                     <ram:CountrySubDivisionName>RegionC</ram:CountrySubDivisionName>
                 </ram:PostalTradeAddress>
                 <ram:SpecifiedTaxRegistration>
-                    <ram:ID schemeID="VAT">NO967611265MVA</ram:ID>
+                    <ram:ID schemeID="VA">NO967611265MVA</ram:ID>
                 </ram:SpecifiedTaxRegistration>
             </ram:SellerTaxRepresentativeTradeParty>
             <ram:BuyerOrderReferencedDocument>

--- a/cii/instance/CII_example3.xml
+++ b/cii/instance/CII_example3.xml
@@ -69,7 +69,7 @@
                     <ram:CountryID>DK</ram:CountryID>
                 </ram:PostalTradeAddress>
                 <ram:SpecifiedTaxRegistration>
-                    <ram:ID schemeID="VAT">DK16356706</ram:ID>
+                    <ram:ID schemeID="VA">DK16356706</ram:ID>
                 </ram:SpecifiedTaxRegistration>
             </ram:SellerTradeParty>
             <ram:BuyerTradeParty>

--- a/cii/instance/CII_example4.xml
+++ b/cii/instance/CII_example4.xml
@@ -130,7 +130,7 @@
                     <ram:CountryID>DK</ram:CountryID>
                 </ram:PostalTradeAddress>
                 <ram:SpecifiedTaxRegistration>
-                    <ram:ID schemeID="VAT">DK16356706</ram:ID>
+                    <ram:ID schemeID="VA">DK16356706</ram:ID>
                 </ram:SpecifiedTaxRegistration>
             </ram:SellerTradeParty>
             <ram:BuyerTradeParty>

--- a/cii/instance/CII_example5.xml
+++ b/cii/instance/CII_example5.xml
@@ -227,7 +227,7 @@
                     <ram:URIID schemeID="email">info@selco.nl</ram:URIID>
                 </ram:URIUniversalCommunication>
                 <ram:SpecifiedTaxRegistration>
-                    <ram:ID schemeID="VAT">NL16356706</ram:ID>
+                    <ram:ID schemeID="VA">NL16356706</ram:ID>
                 </ram:SpecifiedTaxRegistration>
                 <ram:SpecifiedTaxRegistration>
                     <ram:ID schemeID="FC">NL16356706</ram:ID>
@@ -261,7 +261,7 @@
                     <ram:URIID schemeID="email">info@buyercompany.dk</ram:URIID>
                 </ram:URIUniversalCommunication>
                 <ram:SpecifiedTaxRegistration>
-                    <ram:ID schemeID="VAT">DK16356607</ram:ID>
+                    <ram:ID schemeID="VA">DK16356607</ram:ID>
                 </ram:SpecifiedTaxRegistration>
             </ram:BuyerTradeParty>
             <ram:SellerTaxRepresentativeTradeParty>
@@ -275,7 +275,7 @@
                     <ram:CountrySubDivisionName>Jutland</ram:CountrySubDivisionName>
                 </ram:PostalTradeAddress>
                 <ram:SpecifiedTaxRegistration>
-                    <ram:ID schemeID="VAT">DK16356609</ram:ID>
+                    <ram:ID schemeID="VA">DK16356609</ram:ID>
                 </ram:SpecifiedTaxRegistration>
             </ram:SellerTaxRepresentativeTradeParty>
             <ram:SellerOrderReferencedDocument>

--- a/cii/instance/CII_example6.xml
+++ b/cii/instance/CII_example6.xml
@@ -106,7 +106,7 @@
                     <ram:CountryID>DK</ram:CountryID>
                 </ram:PostalTradeAddress>
                 <ram:SpecifiedTaxRegistration>
-                    <ram:ID schemeID="VAT">DK123456789MVA</ram:ID>
+                    <ram:ID schemeID="VA">DK123456789MVA</ram:ID>
                 </ram:SpecifiedTaxRegistration>
             </ram:SellerTradeParty>
             <ram:BuyerTradeParty>

--- a/cii/instance/CII_example8.xml
+++ b/cii/instance/CII_example8.xml
@@ -413,7 +413,7 @@ www.enexis.nl</ram:Content>
                     <ram:CountryID>NL</ram:CountryID>
                 </ram:PostalTradeAddress>
                 <ram:SpecifiedTaxRegistration>
-                    <ram:ID schemeID="VAT">NL809561074B01</ram:ID>
+                    <ram:ID schemeID="VA">NL809561074B01</ram:ID>
                 </ram:SpecifiedTaxRegistration>
             </ram:SellerTradeParty>
             <ram:BuyerTradeParty>

--- a/cii/instance/CII_example9.xml
+++ b/cii/instance/CII_example9.xml
@@ -87,7 +87,7 @@ het factuurnummer. Het bankrekeningnummer is 37.78.15.500, Rabobank, t.n.v. Blue
                     <ram:CountryID>NL</ram:CountryID>
                 </ram:PostalTradeAddress>
                 <ram:SpecifiedTaxRegistration>
-                    <ram:ID schemeID="VAT">NL809163160B01</ram:ID>
+                    <ram:ID schemeID="VA">NL809163160B01</ram:ID>
                 </ram:SpecifiedTaxRegistration>
             </ram:SellerTradeParty>
             <ram:BuyerTradeParty>


### PR DESCRIPTION
Fixes #139 - Using 'VA' instead 'VAT' as schemeID value according to BT-31 and BT-63