### PR TITLE
Fixes UBL-SR-43 issue when root is not using default namespace

### DIFF
--- a/test/CreditNote-unit-UBL/UBL-SR-43.xml
+++ b/test/CreditNote-unit-UBL/UBL-SR-43.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed under European Union Public Licence (EUPL) version 1.2.
+
+-->
+<testSet xmlns="http://difi.no/xsd/vefa/validator/1.0" configuration="tc434-ubl">
+	<assert>
+		<description>x</description>
+		<scope>UBL-SR-43</scope>
+	</assert>
+
+	<test id="1">
+		<assert>
+			<success>UBL-SR-43</success>
+		</assert>
+		<CreditNote
+			xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+			xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+			xmlns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2">
+
+		  <cac:AdditionalDocumentReference>
+		    <cbc:ID>ID</cbc:ID>
+		    <cbc:DocumentTypeCode>50</cbc:DocumentTypeCode>
+		  </cac:AdditionalDocumentReference>
+
+		</CreditNote>
+	</test>
+
+	<test id="2">
+		<assert>
+			<description>When not using default namespace</description>
+			<success>UBL-SR-43</success>
+		</assert>
+		<ns:CreditNote
+			xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+			xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+			xmlns:ns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2">
+
+		  <cac:AdditionalDocumentReference>
+		    <cbc:ID>ID</cbc:ID>
+		    <cbc:DocumentTypeCode>50</cbc:DocumentTypeCode>
+		  </cac:AdditionalDocumentReference>
+
+		</ns:CreditNote>
+	</test>
+
+
+</testSet>

--- a/ubl/schematron/UBL/EN16931-UBL-syntax.sch
+++ b/ubl/schematron/UBL/EN16931-UBL-syntax.sch
@@ -48,7 +48,7 @@
   <param name="UBL-SR-39" value="(count(cac:ProjectReference/cbc:ID) &lt;= 1)"/>
   <param name="UBL-SR-40" value="(count(cac:AccountingCustomerParty/cac:Party/cac:PartyName/cbc:Name) &lt;= 1)"/>
   <param name="UBL-SR-42" value="(count(cac:PartyTaxScheme) &lt;= 2)"/>
-  <param name="UBL-SR-43" value="((cbc:DocumentTypeCode='130') or ((name(/*) = 'CreditNote') and (cbc:DocumentTypeCode='50')) or (not(cbc:ID/@scheme) and not(cbc:DocumentTypeCode)))"/>
+  <param name="UBL-SR-43" value="((cbc:DocumentTypeCode='130') or ((local-name(/*) = 'CreditNote') and (cbc:DocumentTypeCode='50')) or (not(cbc:ID/@scheme) and not(cbc:DocumentTypeCode)))"/>
   <param name="UBL-SR-44" value="count(//cbc:PaymentID[not(preceding::cbc:PaymentID/. = .)]) &lt;= 1"/>
   <param name="UBL-SR-45" value="(count(cac:PaymentMeans/cbc:PaymentDueDate) &lt;=1)"/>
   <param name="UBL-SR-46" value="(count(cac:PaymentMeans/cbc:PaymentMeansCode/@name) &lt;=1)"/>


### PR DESCRIPTION
Hi,

The rule currently expects root to use default namespace. Following example will trigger the error:

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<ns:CreditNote xmlns:ns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
  <cac:AdditionalDocumentReference>
    <cbc:ID>2 Ordre</cbc:ID>
    <cbc:DocumentTypeCode>50</cbc:DocumentTypeCode>
  </cac:AdditionalDocumentReference>
</ns:CreditNote>
```

BR,
Jussi