### PR TITLE
Fixing #234

### DIFF
--- a/pom-license.xml
+++ b/pom-license.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.helger</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.11.3</version>
+    <version>1.11.4</version>
   </parent>
   <artifactId>centc434-validation-rules</artifactId>
   <version>1.3.0</version>

--- a/pom-preprocess.xml
+++ b/pom-preprocess.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.helger</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.11.3</version>
+    <version>1.11.4</version>
   </parent>
   <artifactId>centc434-validation-rules</artifactId>
   <version>1.0.0</version>
@@ -29,7 +29,7 @@
       <plugin>
         <groupId>com.helger.maven</groupId>
         <artifactId>ph-schematron-maven-plugin</artifactId>
-        <version>6.2.1</version>
+        <version>6.2.2</version>
         <executions>
           <execution>
             <id>cii</id>
@@ -69,6 +69,9 @@
           <keepDiagnostics>false</keepDiagnostics>
           <keepReports>false</keepReports>
           <keepEmptyPatterns>false</keepEmptyPatterns>
+          <schHeader>Schematron version 1.3.7-DRAFT
+Last update: 2021-09-27
+</schHeader>
         </configuration>
       </plugin>
     </plugins>

--- a/pom-validate.xml
+++ b/pom-validate.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.helger</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.11.3</version>
+    <version>1.11.4</version>
   </parent>
   <artifactId>centc434-validation-rules</artifactId>
   <version>1.0.0</version>
@@ -29,7 +29,7 @@
       <plugin>
         <groupId>com.helger.maven</groupId>
         <artifactId>ph-schematron-maven-plugin</artifactId>
-        <version>6.2.1</version>
+        <version>6.2.2</version>
         <executions>
           <execution>
             <id>cii</id>

--- a/pom-xslt.xml
+++ b/pom-xslt.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.helger</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.11.3</version>
+    <version>1.11.4</version>
   </parent>
   <artifactId>centc434-validation-rules</artifactId>
   <version>1.0.0</version>
@@ -29,7 +29,7 @@
       <plugin>
         <groupId>com.helger.maven</groupId>
         <artifactId>ph-schematron-maven-plugin</artifactId>
-        <version>6.2.1</version>
+        <version>6.2.2</version>
         <executions>
 <!--
 -->
@@ -70,6 +70,9 @@
         </executions>
         <configuration>
           <schematronPattern>*.sch</schematronPattern>
+          <xsltHeader>Schematron version 1.3.7-DRAFT
+Last update: 2021-09-27
+</xsltHeader>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
It takes ~15 minutes until the ph-schematron 6.2.2 is available in Maven Central. Aftwards you should be fine.

(Please check the existance of the file https://repo1.maven.org/maven2/com/helger/schematron/ph-schematron-testfiles/6.2.2/ph-schematron-testfiles-6.2.2.pom before merging)