### PR TITLE
improve date validation regex for rule CII-DT-097

### DIFF
--- a/cii/schematron/CII/EN16931-CII-syntax.sch
+++ b/cii/schematron/CII/EN16931-CII-syntax.sch
@@ -612,7 +612,7 @@
 	<param name="CII-DT-095" value="not(ram:DepartmentName)"/>
 	<param name="CII-DT-096" value="not(ram:AdditionalStreetName)"/>
 	<!-- DateTimeString -->
-	<param name="CII-DT-097" value="matches(.,'^\s*(\d{8})\s*$')"/>
+	<param name="CII-DT-097" value="matches(.,'^\s*(\d{4})(1[0-2]|0[1-9])(3[01]|[12][0-9]|0[1-9])\s*$')"/>
 	
     <!-- Sections -->
     

--- a/cii/xslt/EN16931-CII-validation.xslt
+++ b/cii/xslt/EN16931-CII-validation.xslt
@@ -11785,9 +11785,9 @@
 
 		<!--ASSERT -->
 <xsl:choose>
-      <xsl:when test="matches(.,'^\s*(\d{4})(1[0-2]|0[1-9]){1}(3[01]|[12][0-9]|0[1-9]){1}\s*$')" />
+      <xsl:when test="matches(.,'^\s*(\d{8})\s*$')" />
       <xsl:otherwise>
-        <svrl:failed-assert test="matches(.,'^\s*(\d{4})(1[0-2]|0[1-9]){1}(3[01]|[12][0-9]|0[1-9]){1}\s*$')">
+        <svrl:failed-assert test="matches(.,'^\s*(\d{8})\s*$')">
           <xsl:attribute name="id">CII-DT-097</xsl:attribute>
           <xsl:attribute name="flag">fatal</xsl:attribute>
           <xsl:attribute name="location">

--- a/cii/xslt/EN16931-CII-validation.xslt
+++ b/cii/xslt/EN16931-CII-validation.xslt
@@ -11785,9 +11785,9 @@
 
 		<!--ASSERT -->
 <xsl:choose>
-      <xsl:when test="matches(.,'^\s*(\d{8})\s*$')" />
+      <xsl:when test="matches(.,'^\s*(\d{4})(1[0-2]|0[1-9]){1}(3[01]|[12][0-9]|0[1-9]){1}\s*$')" />
       <xsl:otherwise>
-        <svrl:failed-assert test="matches(.,'^\s*(\d{8})\s*$')">
+        <svrl:failed-assert test="matches(.,'^\s*(\d{4})(1[0-2]|0[1-9]){1}(3[01]|[12][0-9]|0[1-9]){1}\s*$')">
           <xsl:attribute name="id">CII-DT-097</xsl:attribute>
           <xsl:attribute name="flag">fatal</xsl:attribute>
           <xsl:attribute name="location">


### PR DESCRIPTION
The date validation CII-DT-097 only validates that the date has 8 digits. Unfortunately this leads to problems in our downstream tooling. This PR introduces an reges which validates as following
year: The first 4 non-empty characters must be digits and represent the year (possible values 0000 - 9999)
month: The next two characters must be digits in the range 01-12
day: The next two characters must be digits in the range 01-31

This still allows for invalid dates of the kind 20230231 but at least allow for a static month digits to string conversion, i.e. 01 -> January etc.