### PR TITLE
fixed path in BR-DEC-23 in CII

### DIFF
--- a/cii/schematron/CII/EN16931-CII-model.sch
+++ b/cii/schematron/CII/EN16931-CII-model.sch
@@ -237,7 +237,7 @@
   <param name="BR-DEC-18" value="string-length(substring-after(ram:DuePayableAmount,'.'))&lt;=2"/>
   <param name="BR-DEC-19" value="string-length(substring-after(ram:BasisAmount,'.'))&lt;=2"/>
   <param name="BR-DEC-20" value="string-length(substring-after(ram:CalculatedAmount,'.'))&lt;=2"/>
-  <param name="BR-DEC-23" value="string-length(substring-after(ram:SpecifiedTradeSettlement/ram:SpecifiedTradeSettlementLineMonetarySummation/ram:LineTotalAmount,'.'))&lt;=2"/>
+  <param name="BR-DEC-23" value="string-length(substring-after(ram:SpecifiedLineTradeSettlement/ram:SpecifiedTradeSettlementLineMonetarySummation/ram:LineTotalAmount,'.'))&lt;=2"/>
   <param name="BR-DEC-24" value="string-length(substring-after(ram:ActualAmount,'.'))&lt;=2"/>
   <param name="BR-DEC-25" value="string-length(substring-after(ram:BasisAmount,'.'))&lt;=2"/>
   <param name="BR-DEC-27" value="string-length(substring-after(ram:ActualAmount,'.'))&lt;=2"/>


### PR DESCRIPTION
Invoice line net amount (BT-131) is restricted to two decimals, but the rule is not firing (see sample file) due to a typo in BR-DEC-23 path check. 

[cii-br-dec-23-test.txt](https://github.com/ConnectingEurope/eInvoicing-EN16931/files/13727254/cii-br-dec-23-test.txt)