### PR TITLE
One kind of value for BT-8/BT-7 within the invoice document

### DIFF
--- a/cii/schematron/CII/EN16931-CII-model.sch
+++ b/cii/schematron/CII/EN16931-CII-model.sch
@@ -68,6 +68,7 @@
   
   <!--param name="BR-CO-02" value="((ram:TypeCode = ('30','57')) and (ram:PayeePartyCreditorFinancialAccount/ram:IBANID or ram:PayeePartyCreditorFinancialAccount/ram:ProprietaryID)) or not(ram:TypeCode =  ('30','57'))"/-->
   <param name="BR-CO-03" value="((//ram:TaxPointDate) and not(//ram:DueDateTypeCode)) or (not (//ram:TaxPointDate) and (//ram:DueDateTypeCode)) or (not (//ram:TaxPointDate) and not (//ram:DueDateTypeCode))"/>
+								<!--(exists(cbc:TaxPointDate) and not(cac:InvoicePeriod/cbc:DescriptionCode)) or (not(cbc:TaxPointDate) and exists(cac:InvoicePeriod/cbc:DescriptionCode)) or (not(cbc:TaxPointDate) and not(cac:InvoicePeriod/cbc:DescriptionCode))">[BR-CO-03]-Value added tax point date (BT-7) and Value added tax point date code (BT-8) are mutually exclusive.</assert>    -->
   <param name="BR-CO-04" value="(ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax[upper-case(ram:TypeCode) = 'VAT']/ram:CategoryCode)"/>
   <param name="BR-CO-05" value="true()"/>
   <param name="BR-CO-06" value="true()"/>

--- a/cii/schematron/CII/EN16931-CII-syntax.sch
+++ b/cii/schematron/CII/EN16931-CII-syntax.sch
@@ -630,8 +630,10 @@
 	<param name="CII-SR-453" value="count(ram:SpecifiedTradePaymentTerms/ram:Description) &lt;= 1"/>
 	<param name="CII-SR-459" value="count(ram:SellerTradeParty/ram:URIUniversalCommunication) &lt;= 1"/>
 	<param name="CII-SR-460" value="count(ram:BuyerTradeParty/ram:URIUniversalCommunication) &lt;= 1"/>
-	<param name="CII-SR-461" value="count(ram:ApplicableTradeTax/ram:TaxPointDate[2]) &lt; 1"/>
-	<param name="CII-SR-462" value="count(ram:ApplicableTradeTax/ram:DueDateTypeCode[2]) &lt; 1"/>
+	<param name="CII-SR-461" value="count(ram:ApplicableTradeTax/ram:DueDateTypeCode) = count(ram:ApplicableTradeTax/ram:DueDateTypeCode[text() = '5']) or 
+									count(ram:ApplicableTradeTax/ram:DueDateTypeCode) = count(ram:ApplicableTradeTax/ram:DueDateTypeCode[text() = '29']) or 
+									count(ram:ApplicableTradeTax/ram:DueDateTypeCode) = count(ram:ApplicableTradeTax/ram:DueDateTypeCode[text() = '72'])"/>
+	<param name="CII-SR-462" value="count(ram:ApplicableTradeTax/ram:TaxPointDate/udt:DateString) = count(ram:ApplicableTradeTax/ram:TaxPointDate/udt:DateString[text() = (//ram:ApplicableTradeTax/ram:TaxPointDate/udt:DateString)[1]/text()])"/>
 	
 	<!-- Invoice -->
 	<param name="CII-SR-438" value="not(ram:ValuationBreakdownStatement)"/>

--- a/cii/schematron/CII/EN16931-CII-syntax.sch
+++ b/cii/schematron/CII/EN16931-CII-syntax.sch
@@ -630,8 +630,8 @@
 	<param name="CII-SR-453" value="count(ram:SpecifiedTradePaymentTerms/ram:Description) &lt;= 1"/>
 	<param name="CII-SR-459" value="count(ram:SellerTradeParty/ram:URIUniversalCommunication) &lt;= 1"/>
 	<param name="CII-SR-460" value="count(ram:BuyerTradeParty/ram:URIUniversalCommunication) &lt;= 1"/>
-	<param name="CII-SR-461" value="count(ram:ApplicableTradeTax/ram:TaxPointDate) &lt;= 1"/>
-	<param name="CII-SR-462" value="count(ram:ApplicableTradeTax/ram:DueDateTypeCode) &lt;= 1"/>
+	<param name="CII-SR-461" value="count(ram:ApplicableTradeTax/ram:TaxPointDate[2]) &lt; 1"/>
+	<param name="CII-SR-462" value="count(ram:ApplicableTradeTax/ram:DueDateTypeCode[2]) &lt; 1"/>
 	
 	<!-- Invoice -->
 	<param name="CII-SR-438" value="not(ram:ValuationBreakdownStatement)"/>

--- a/cii/schematron/abstract/EN16931-CII-syntax.sch
+++ b/cii/schematron/abstract/EN16931-CII-syntax.sch
@@ -513,8 +513,8 @@
 		<assert test="$CII-SR-437" flag="warning" id="CII-SR-437">[CII-SR-437] - UltimatePayeeTradeParty should not be present</assert>
 		<assert test="$CII-SR-452" flag="warning" id="CII-SR-452">[CII-SR-452] - Only one SpecifiedTradePaymentTerms should be present</assert>
 		<assert test="$CII-SR-453" flag="warning" id="CII-SR-453">[CII-SR-453] - Only one SpecifiedTradePaymentTerms Description should be present</assert>
-		<assert test="$CII-SR-461" flag="fatal" id="CII-SR-461">[CII-SR-461] - Only one TaxPointDate shall be present</assert>		
-		<assert test="$CII-SR-462" flag="fatal" id="CII-SR-462">[CII-SR-462] - Only one DueDateTypeCode shall be present</assert>		
+		<assert test="$CII-SR-461" flag="fatal" id="CII-SR-461">[CII-SR-461] - Only one kind of TaxPointDate value shall be present in the document</assert>
+		<assert test="$CII-SR-462" flag="fatal" id="CII-SR-462">[CII-SR-462] - Only one kind of DueDateTypeCode value shall be present in the document</assert>
 	</rule>
 	<rule context="$SpecifiedTradeSettlementHeaderMonetarySummation">
 

--- a/cii/schematron/preprocessed/EN16931-CII-validation-preprocessed.sch
+++ b/cii/schematron/preprocessed/EN16931-CII-validation-preprocessed.sch
@@ -121,7 +121,7 @@
       <assert id="BR-64" flag="fatal" test="normalize-space(ram:SpecifiedTradeProduct/ram:GlobalID/@schemeID) != '' or not (ram:SpecifiedTradeProduct/ram:GlobalID)">[BR-64]-The Item standard identifier (BT-157) shall have a Scheme identifier.</assert>
       <assert id="BR-CO-04" flag="fatal" test="(ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax[upper-case(ram:TypeCode) = 'VAT']/ram:CategoryCode)">[BR-CO-04]-Each Invoice line (BG-25) shall be categorized with an Invoiced item VAT category code (BT-151).</assert>
       <assert id="BR-CO-18" flag="fatal" test="//rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax">[BR-CO-18]-An Invoice shall at least have one VAT breakdown group (BG-23).</assert>
-      <assert id="BR-DEC-23" flag="fatal" test="string-length(substring-after(ram:SpecifiedTradeSettlement/ram:SpecifiedTradeSettlementLineMonetarySummation/ram:LineTotalAmount,'.'))&lt;=2">[BR-DEC-23]-The allowed maximum number of decimals for the Invoice line net amount (BT-131) is 2.</assert>
+      <assert id="BR-DEC-23" flag="fatal" test="string-length(substring-after(ram:SpecifiedLineTradeSettlement/ram:SpecifiedTradeSettlementLineMonetarySummation/ram:LineTotalAmount,'.'))&lt;=2">[BR-DEC-23]-The allowed maximum number of decimals for the Invoice line net amount (BT-131) is 2.</assert>
     </rule>
     <rule context="//ram:SpecifiedLineTradeSettlement/ram:SpecifiedTradeAllowanceCharge/ram:ChargeIndicator[udt:Indicator = 'false']">
       <assert id="BR-41" flag="fatal" test="(../ram:ActualAmount)">[BR-41]-Each Invoice line allowance (BG-27) shall have an Invoice line allowance amount (BT-136).</assert>
@@ -806,8 +806,8 @@
       <assert id="CII-SR-437" flag="warning" test="not(ram:UltimatePayeeTradeParty)">[CII-SR-437] - UltimatePayeeTradeParty should not be present</assert>
       <assert id="CII-SR-452" flag="warning" test="count(ram:SpecifiedTradePaymentTerms) &lt;= 1">[CII-SR-452] - Only one SpecifiedTradePaymentTerms should be present</assert>
       <assert id="CII-SR-453" flag="warning" test="count(ram:SpecifiedTradePaymentTerms/ram:Description) &lt;= 1">[CII-SR-453] - Only one SpecifiedTradePaymentTerms Description should be present</assert>
-      <assert id="CII-SR-461" flag="fatal" test="count(ram:ApplicableTradeTax/ram:TaxPointDate) &lt;= 1">[CII-SR-461] - Only one TaxPointDate shall be present</assert>
-      <assert id="CII-SR-462" flag="fatal" test="count(ram:ApplicableTradeTax/ram:DueDateTypeCode) &lt;= 1">[CII-SR-462] - Only one DueDateTypeCode shall be present</assert>
+      <assert id="CII-SR-461" flag="fatal" test="count(ram:ApplicableTradeTax/ram:TaxPointDate[2]) &lt; 1">[CII-SR-461] - Only one TaxPointDate shall be present</assert>
+      <assert id="CII-SR-462" flag="fatal" test="count(ram:ApplicableTradeTax/ram:DueDateTypeCode[2]) &lt; 1">[CII-SR-462] - Only one DueDateTypeCode shall be present</assert>
     </rule>
     <rule context="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementHeaderMonetarySummation">
       <assert id="CII-SR-411" flag="warning" test="not(ram:InformationAmount)">[CII-SR-411] - InformationAmount should not be present</assert>
@@ -830,16 +830,20 @@
       <assert id="CII-SR-04" flag="warning" test="not(ram:Value)">[CII-SR-004] - Value should not be present</assert>
       <assert id="CII-SR-05" flag="warning" test="not(ram:SpecifiedDocumentVersion)">[CII-SR-005] - SpecifiedDocumentVersion should not be present</assert>
     </rule>
-    <rule context="/rsm:CrossIndustryInvoice/*[self::rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID or         self::rsm:ExchangedDocument/ram:ID or self::rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:AssociatedDocumentLineDocument/ram:LineID or         self::rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedTradeProduct/ram:SellerAssignedID]">
+    <rule context="/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID |            /rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:ID |            /rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:AssociatedDocumentLineDocument/ram:LineID |            /rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedTradeProduct/ram:SellerAssignedID">
+      <assert id="CII-DT-001" flag="fatal" test="not(@schemeName)">[CII-DT-001] - schemeName should not be present</assert>
+      <assert id="CII-DT-002" flag="fatal" test="not(@schemeAgencyName)">[CII-DT-002] - schemeAgencyName should not be present</assert>
+      <assert id="CII-DT-003" flag="fatal" test="not(@schemeDataURI)">[CII-DT-003] - schemeDataURI should not be present</assert>
+      <assert id="CII-DT-004" flag="fatal" test="not(@schemeURI)">[CII-DT-004] - schemeURI should not be present</assert>
       <assert id="CII-DT-005" flag="fatal" test="not(@schemeID)">[CII-DT-005] - schemeID should not be present</assert>
       <assert id="CII-DT-006" flag="fatal" test="not(@schemeAgencyID)">[CII-DT-006] - schemeAgencyID should not be present</assert>
       <assert id="CII-DT-007" flag="fatal" test="not(@schemeVersionID)">[CII-DT-007] - schemeVersionID should not be present</assert>
     </rule>
     <rule context="//ram:*[ends-with(name(), 'ID')]">
-      <assert id="CII-DT-001" flag="fatal" test="not(@schemeName)">[CII-DT-001] - schemeName should not be present</assert>
-      <assert id="CII-DT-002" flag="fatal" test="not(@schemeAgencyName)">[CII-DT-002] - schemeAgencyName should not be present</assert>
-      <assert id="CII-DT-003" flag="fatal" test="not(@schemeDataURI)">[CII-DT-003] - schemeDataURI should not be present</assert>
-      <assert id="CII-DT-004" flag="fatal" test="not(@schemeURI)">[CII-DT-004] - schemeURI should not be present</assert>
+      <assert id="CII-DT-0010" flag="fatal" test="not(@schemeName)">[CII-DT-001] - schemeName should not be present</assert>
+      <assert id="CII-DT-0020" flag="fatal" test="not(@schemeAgencyName)">[CII-DT-002] - schemeAgencyName should not be present</assert>
+      <assert id="CII-DT-0030" flag="fatal" test="not(@schemeDataURI)">[CII-DT-003] - schemeDataURI should not be present</assert>
+      <assert id="CII-DT-0040" flag="fatal" test="not(@schemeURI)">[CII-DT-004] - schemeURI should not be present</assert>
     </rule>
     <rule context="//ram:TypeCode">
       <assert id="CII-DT-008" flag="fatal" test="not(@name)">[CII-DT-008] - name should not be present</assert>

--- a/cii/schematron/preprocessed/EN16931-CII-validation-preprocessed.sch
+++ b/cii/schematron/preprocessed/EN16931-CII-validation-preprocessed.sch
@@ -806,8 +806,8 @@
       <assert id="CII-SR-437" flag="warning" test="not(ram:UltimatePayeeTradeParty)">[CII-SR-437] - UltimatePayeeTradeParty should not be present</assert>
       <assert id="CII-SR-452" flag="warning" test="count(ram:SpecifiedTradePaymentTerms) &lt;= 1">[CII-SR-452] - Only one SpecifiedTradePaymentTerms should be present</assert>
       <assert id="CII-SR-453" flag="warning" test="count(ram:SpecifiedTradePaymentTerms/ram:Description) &lt;= 1">[CII-SR-453] - Only one SpecifiedTradePaymentTerms Description should be present</assert>
-      <assert id="CII-SR-461" flag="fatal" test="count(ram:ApplicableTradeTax/ram:TaxPointDate[2]) &lt; 1">[CII-SR-461] - Only one TaxPointDate shall be present</assert>
-      <assert id="CII-SR-462" flag="fatal" test="count(ram:ApplicableTradeTax/ram:DueDateTypeCode[2]) &lt; 1">[CII-SR-462] - Only one DueDateTypeCode shall be present</assert>
+      <assert id="CII-SR-461" flag="fatal" test="count(ram:ApplicableTradeTax/ram:DueDateTypeCode) = count(ram:ApplicableTradeTax/ram:DueDateTypeCode[text() = '5']) or           count(ram:ApplicableTradeTax/ram:DueDateTypeCode) = count(ram:ApplicableTradeTax/ram:DueDateTypeCode[text() = '29']) or           count(ram:ApplicableTradeTax/ram:DueDateTypeCode) = count(ram:ApplicableTradeTax/ram:DueDateTypeCode[text() = '72'])">[CII-SR-461] - Only one kind of TaxPointDate value shall be present in the document</assert>
+      <assert id="CII-SR-462" flag="fatal" test="count(ram:ApplicableTradeTax/ram:TaxPointDate/udt:DateString) = count(ram:ApplicableTradeTax/ram:TaxPointDate/udt:DateString[text() = (//ram:ApplicableTradeTax/ram:TaxPointDate/udt:DateString)[1]/text()])">[CII-SR-462] - Only one kind of DueDateTypeCode value shall be present in the document</assert>
     </rule>
     <rule context="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementHeaderMonetarySummation">
       <assert id="CII-SR-411" flag="warning" test="not(ram:InformationAmount)">[CII-SR-411] - InformationAmount should not be present</assert>

--- a/cii/xslt/EN16931-CII-validation.xslt
+++ b/cii/xslt/EN16931-CII-validation.xslt
@@ -1458,9 +1458,9 @@
 
 		<!--ASSERT -->
 <xsl:choose>
-      <xsl:when test="string-length(substring-after(ram:SpecifiedTradeSettlement/ram:SpecifiedTradeSettlementLineMonetarySummation/ram:LineTotalAmount,'.'))&lt;=2" />
+      <xsl:when test="string-length(substring-after(ram:SpecifiedLineTradeSettlement/ram:SpecifiedTradeSettlementLineMonetarySummation/ram:LineTotalAmount,'.'))&lt;=2" />
       <xsl:otherwise>
-        <svrl:failed-assert test="string-length(substring-after(ram:SpecifiedTradeSettlement/ram:SpecifiedTradeSettlementLineMonetarySummation/ram:LineTotalAmount,'.'))&lt;=2">
+        <svrl:failed-assert test="string-length(substring-after(ram:SpecifiedLineTradeSettlement/ram:SpecifiedTradeSettlementLineMonetarySummation/ram:LineTotalAmount,'.'))&lt;=2">
           <xsl:attribute name="id">BR-DEC-23</xsl:attribute>
           <xsl:attribute name="flag">fatal</xsl:attribute>
           <xsl:attribute name="location">
@@ -10222,9 +10222,9 @@
 
 		<!--ASSERT -->
 <xsl:choose>
-      <xsl:when test="count(ram:ApplicableTradeTax/ram:TaxPointDate) &lt;= 1" />
+      <xsl:when test="count(ram:ApplicableTradeTax/ram:TaxPointDate[2]) &lt; 1" />
       <xsl:otherwise>
-        <svrl:failed-assert test="count(ram:ApplicableTradeTax/ram:TaxPointDate) &lt;= 1">
+        <svrl:failed-assert test="count(ram:ApplicableTradeTax/ram:TaxPointDate[2]) &lt; 1">
           <xsl:attribute name="id">CII-SR-461</xsl:attribute>
           <xsl:attribute name="flag">fatal</xsl:attribute>
           <xsl:attribute name="location">
@@ -10237,9 +10237,9 @@
 
 		<!--ASSERT -->
 <xsl:choose>
-      <xsl:when test="count(ram:ApplicableTradeTax/ram:DueDateTypeCode) &lt;= 1" />
+      <xsl:when test="count(ram:ApplicableTradeTax/ram:DueDateTypeCode[2]) &lt; 1" />
       <xsl:otherwise>
-        <svrl:failed-assert test="count(ram:ApplicableTradeTax/ram:DueDateTypeCode) &lt;= 1">
+        <svrl:failed-assert test="count(ram:ApplicableTradeTax/ram:DueDateTypeCode[2]) &lt; 1">
           <xsl:attribute name="id">CII-SR-462</xsl:attribute>
           <xsl:attribute name="flag">fatal</xsl:attribute>
           <xsl:attribute name="location">
@@ -10496,8 +10496,68 @@
   </xsl:template>
 
 	<!--RULE -->
-<xsl:template match="/rsm:CrossIndustryInvoice/*[self::rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID or         self::rsm:ExchangedDocument/ram:ID or self::rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:AssociatedDocumentLineDocument/ram:LineID or         self::rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedTradeProduct/ram:SellerAssignedID]" mode="M11" priority="1011">
-    <svrl:fired-rule context="/rsm:CrossIndustryInvoice/*[self::rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID or         self::rsm:ExchangedDocument/ram:ID or self::rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:AssociatedDocumentLineDocument/ram:LineID or         self::rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedTradeProduct/ram:SellerAssignedID]" />
+<xsl:template match="/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID |            /rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:ID |            /rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:AssociatedDocumentLineDocument/ram:LineID |            /rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedTradeProduct/ram:SellerAssignedID" mode="M11" priority="1011">
+    <svrl:fired-rule context="/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID |            /rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:ID |            /rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:AssociatedDocumentLineDocument/ram:LineID |            /rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedTradeProduct/ram:SellerAssignedID" />
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(@schemeName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(@schemeName)">
+          <xsl:attribute name="id">CII-DT-001</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[CII-DT-001] - schemeName should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(@schemeAgencyName)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(@schemeAgencyName)">
+          <xsl:attribute name="id">CII-DT-002</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[CII-DT-002] - schemeAgencyName should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(@schemeDataURI)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(@schemeDataURI)">
+          <xsl:attribute name="id">CII-DT-003</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[CII-DT-003] - schemeDataURI should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
+
+		<!--ASSERT -->
+<xsl:choose>
+      <xsl:when test="not(@schemeURI)" />
+      <xsl:otherwise>
+        <svrl:failed-assert test="not(@schemeURI)">
+          <xsl:attribute name="id">CII-DT-004</xsl:attribute>
+          <xsl:attribute name="flag">fatal</xsl:attribute>
+          <xsl:attribute name="location">
+            <xsl:apply-templates mode="schematron-select-full-path" select="." />
+          </xsl:attribute>
+          <svrl:text>[CII-DT-004] - schemeURI should not be present</svrl:text>
+        </svrl:failed-assert>
+      </xsl:otherwise>
+    </xsl:choose>
 
 		<!--ASSERT -->
 <xsl:choose>

--- a/cii/xslt/EN16931-CII-validation.xslt
+++ b/cii/xslt/EN16931-CII-validation.xslt
@@ -10222,30 +10222,30 @@
 
 		<!--ASSERT -->
 <xsl:choose>
-      <xsl:when test="count(ram:ApplicableTradeTax/ram:TaxPointDate[2]) &lt; 1" />
+      <xsl:when test="count(ram:ApplicableTradeTax/ram:DueDateTypeCode) = count(ram:ApplicableTradeTax/ram:DueDateTypeCode[text() = '5']) or           count(ram:ApplicableTradeTax/ram:DueDateTypeCode) = count(ram:ApplicableTradeTax/ram:DueDateTypeCode[text() = '29']) or           count(ram:ApplicableTradeTax/ram:DueDateTypeCode) = count(ram:ApplicableTradeTax/ram:DueDateTypeCode[text() = '72'])" />
       <xsl:otherwise>
-        <svrl:failed-assert test="count(ram:ApplicableTradeTax/ram:TaxPointDate[2]) &lt; 1">
+        <svrl:failed-assert test="count(ram:ApplicableTradeTax/ram:DueDateTypeCode) = count(ram:ApplicableTradeTax/ram:DueDateTypeCode[text() = '5']) or count(ram:ApplicableTradeTax/ram:DueDateTypeCode) = count(ram:ApplicableTradeTax/ram:DueDateTypeCode[text() = '29']) or count(ram:ApplicableTradeTax/ram:DueDateTypeCode) = count(ram:ApplicableTradeTax/ram:DueDateTypeCode[text() = '72'])">
           <xsl:attribute name="id">CII-SR-461</xsl:attribute>
           <xsl:attribute name="flag">fatal</xsl:attribute>
           <xsl:attribute name="location">
             <xsl:apply-templates mode="schematron-select-full-path" select="." />
           </xsl:attribute>
-          <svrl:text>[CII-SR-461] - Only one TaxPointDate shall be present</svrl:text>
+          <svrl:text>[CII-SR-461] - Only one kind of TaxPointDate value shall be present in the document</svrl:text>
         </svrl:failed-assert>
       </xsl:otherwise>
     </xsl:choose>
 
 		<!--ASSERT -->
 <xsl:choose>
-      <xsl:when test="count(ram:ApplicableTradeTax/ram:DueDateTypeCode[2]) &lt; 1" />
+      <xsl:when test="count(ram:ApplicableTradeTax/ram:TaxPointDate/udt:DateString) = count(ram:ApplicableTradeTax/ram:TaxPointDate/udt:DateString[text() = (//ram:ApplicableTradeTax/ram:TaxPointDate/udt:DateString)[1]/text()])" />
       <xsl:otherwise>
-        <svrl:failed-assert test="count(ram:ApplicableTradeTax/ram:DueDateTypeCode[2]) &lt; 1">
+        <svrl:failed-assert test="count(ram:ApplicableTradeTax/ram:TaxPointDate/udt:DateString) = count(ram:ApplicableTradeTax/ram:TaxPointDate/udt:DateString[text() = (//ram:ApplicableTradeTax/ram:TaxPointDate/udt:DateString)[1]/text()])">
           <xsl:attribute name="id">CII-SR-462</xsl:attribute>
           <xsl:attribute name="flag">fatal</xsl:attribute>
           <xsl:attribute name="location">
             <xsl:apply-templates mode="schematron-select-full-path" select="." />
           </xsl:attribute>
-          <svrl:text>[CII-SR-462] - Only one DueDateTypeCode shall be present</svrl:text>
+          <svrl:text>[CII-SR-462] - Only one kind of DueDateTypeCode value shall be present in the document</svrl:text>
         </svrl:failed-assert>
       </xsl:otherwise>
     </xsl:choose>


### PR DESCRIPTION
Please find attached the patch for #387 and #365, it 

1. Fixes a previous patch für #365 and 
2. Provides the updated XSLT according to the given CII Schematron files (the generation seems to be omitted once in the past)