### PR TITLE
Fix variable name for $Credit_Payment_instructions

### DIFF
--- a/cii/schematron/abstract/EN16931-CII-model.sch
+++ b/cii/schematron/abstract/EN16931-CII-model.sch
@@ -141,7 +141,7 @@
   <rule context="$Payment_instructions ">
     <assert test="$BR-49" flag="fatal" id="BR-49">[BR-49]-A Payment instruction (BG-16) shall specify the Payment means type code (BT-81).</assert>
   </rule>
-  <rule context="$Credit_Payment_instructions">
+  <rule context="$Credit_Payment_instructions ">
     <assert test="$BR-CO-27" flag="fatal" id="BR-CO-27">[BR-CO-27]- Either the IBAN or a Proprietary ID (BT-84) shall be used.</assert>
   </rule>
   <rule context="$Preceding_Invoice ">


### PR DESCRIPTION
The use of the variable has a space after the name, while the definition does not. This results in the variable not being expanded when using the Schematron Skeleton implementation, and thus in an xlst file that can't be loaded.

It would probably make more sense to remove the space, but for consistency with the rest of the variables i've added it, rather than remove the one where the variable is used.